### PR TITLE
13주차 문제풀이 박진우

### DIFF
--- a/week13/BOJ_1167/BOJ_1167_박진우.java
+++ b/week13/BOJ_1167/BOJ_1167_박진우.java
@@ -1,0 +1,71 @@
+import java.util.*;
+import java.io.*;
+
+class Node {
+  int n;
+  int dist;
+  
+  Node(int n, int dist) {
+    this.n = n;
+    this.dist = dist;
+  }
+}
+
+public class Main {
+  static List<Node>[] nodes;
+  
+  static void DFS(int n, boolean[] visited, int dist, Node data, int exclude) {
+    for(Node next:nodes[n]) {
+      if(visited[next.n]) continue;
+      visited[next.n] = true;
+      DFS(next.n, visited, dist+next.dist, data, exclude);
+      visited[next.n]= false; 
+    }
+    
+    if(dist>data.dist) {
+      if(n==exclude) return;
+      data.n = n;
+      data.dist = dist;
+    }
+  }
+  
+  public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    StringTokenizer st;
+    
+    int V = Integer.parseInt(br.readLine());
+    nodes = new ArrayList[V+1];
+    
+    for(int i=1; i<=V; i++) {
+      nodes[i] = new ArrayList<>();
+    }
+    
+    for(int i=0; i<V; i++) {
+      st = new StringTokenizer(br.readLine());
+      int from = Integer.parseInt(st.nextToken());
+      int to = Integer.parseInt(st.nextToken());
+      
+      while(to!=-1) {
+        int dist = Integer.parseInt(st.nextToken());
+        
+        nodes[from].add(new Node(to, dist));
+
+        to = Integer.parseInt(st.nextToken());
+      }
+    }
+    
+    Node data = new Node(1, 0); // 임의의 노드
+    boolean visited[] = new boolean[V+1];
+    visited[1] = true;
+    
+    DFS(data.n, visited, 0, data, 0);
+    
+    data.dist = 0;
+    visited = new boolean[V+1];
+    visited[data.n]= true; 
+    
+    DFS(data.n, new boolean[V+1], 0, data, data.n);
+    
+    System.out.println(data.dist);
+  }
+}

--- a/week13/BOJ_1240/BOJ_1240_박진우.java
+++ b/week13/BOJ_1240/BOJ_1240_박진우.java
@@ -1,0 +1,72 @@
+import java.util.*;
+import java.io.*;
+
+class Node implements Comparable<Node>{
+  int n;
+  int dist;
+  
+  Node(int n, int dist){
+    this.n = n;
+    this.dist = dist;
+  }
+
+  @Override
+  public int compareTo(Node o) {
+    return this.dist - o.dist;
+  }
+}
+
+public class Main {
+  public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    StringTokenizer st = new StringTokenizer(br.readLine());
+    
+    int N = Integer.parseInt(st.nextToken());
+    int M = Integer.parseInt(st.nextToken());
+    
+    List<Node>[] nodes = new List[N+1];
+    for(int i=1; i<=N; i++) {
+      nodes[i] = new ArrayList<>();
+    }
+    
+    for(int i=0; i<N-1; i++) {
+      st = new StringTokenizer(br.readLine());
+      int from = Integer.parseInt(st.nextToken());
+      int to = Integer.parseInt(st.nextToken());
+      int cost = Integer.parseInt(st.nextToken());
+      
+      nodes[from].add(new Node(to, cost));
+      nodes[to].add(new Node(from, cost));
+    }
+    
+    for(int i=0; i<M; i++) {
+      st = new StringTokenizer(br.readLine());
+      int from = Integer.parseInt(st.nextToken());
+      int to = Integer.parseInt(st.nextToken());
+      
+      int result = -1;
+      
+      PriorityQueue<Node> pq = new PriorityQueue<>();
+      boolean[] visited = new boolean[N+1];
+      
+      pq.add(new Node(from, 0));
+      visited[from] = true;
+      
+      while(!pq.isEmpty()) {
+        Node node = pq.poll();
+        if(node.n == to) {
+          result = node.dist;
+          break;
+        }
+        
+        for(Node next:nodes[node.n]) {
+          if(visited[next.n]) continue;
+          visited[next.n] = true;
+          pq.add(new Node(next.n, node.dist+next.dist));
+        }
+      }
+      
+      System.out.println(result);
+    }
+  }
+}

--- a/week13/BOJ_1967/BOJ_1967_박진우.java
+++ b/week13/BOJ_1967/BOJ_1967_박진우.java
@@ -1,0 +1,78 @@
+// try 1. 다익스트라 : 리프노드 간의 거리를 구하려 했으나, 트리에서 한 경로에 대해 거리가 갱신될 필요가 없으므로, 비효율
+// try 2. DFS: 루트노드로부터 가장 먼 A 노드에 대해, A로부터 가장 먼 B 노드까지의 거리를 구한다.
+// 그림(원)을 보면, 루트노드로부터 가장 먼 노드 A로부터, 가장 먼 노드 B의 거리가 곧 지름이다.
+
+import java.util.*;
+import java.io.*;
+
+class Node implements Comparable<Node>{
+  int n;
+  int dist;
+  
+  Node(int n, int dist){
+    this.n = n;
+    this.dist = dist;
+  }
+
+  @Override
+  public int compareTo(Node o) {
+    return this.dist - o.dist;
+  }
+}
+
+public class Main {
+  static List<Node>[] nodes;
+  
+  static void DFS(int n, boolean[] visited, int dist, Node data, int exclude) {
+    
+    for(Node next:nodes[n]) {
+      if(visited[next.n]) continue;
+      visited[next.n] = true;
+      DFS(next.n, visited, dist+next.dist, data, exclude);
+      visited[next.n]= false; 
+    }
+    
+    
+    if(dist > data.dist) {
+      if(n==exclude) return;
+      data.n = n;
+      data.dist = dist;
+    }
+  }
+  
+  public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    StringTokenizer st;
+    
+    int N = Integer.parseInt(br.readLine());
+    nodes = new List[N+1];
+    
+    for(int i=1; i<=N; i++) {
+      nodes[i] = new ArrayList<>();
+    }
+    
+    for(int i=0; i<N-1; i++) {
+      st = new StringTokenizer(br.readLine());
+      int from = Integer.parseInt(st.nextToken());
+      int to = Integer.parseInt(st.nextToken());
+      int dist = Integer.parseInt(st.nextToken());
+      
+      nodes[from].add(new Node(to, dist));
+      nodes[to].add(new Node(from, dist));
+    }
+    
+    Node data = new Node(1, 0);
+    boolean[] visited = new boolean[N+1];
+    visited[data.n] = true;
+    
+    DFS(data.n, new boolean[N+1], 0, data, 0);
+    
+    data.dist = 0;
+    visited = new boolean[N+1];
+    visited[data.n] = true;
+    
+    DFS(data.n, new boolean[N+1], 0, data, data.n);
+    
+    System.out.println(data.dist);
+  }
+}


### PR DESCRIPTION
13주차 문제는 `1240`->`1967`->`1167`로 사고를 확장하는 것을 의도해서 출제했습니다.
제가 풀이하면서 접근했던 방법을 아래에 공유드릴게요.

## 1240. 노드사이의 거리
 - BFS와 [다익스트라](https://github.com/Jinops/algorithm/commit/a23cde4690868e1b1670b96b933808f7ae703d20)로 접근
 - 트리는 거리가 업데이트되지 않으므로 다익스트라는 비효율. BFS로 수정

## 1967. 트리의 지름
 - 리프 노드 간의 BFS로 접근
 - 리프 노드 개수*O(V+E) 만큼 탐색을 해야하므로 비효율
 - DFS 두 번으로 해결할 수 있는 방법을 찾음

## 1167. 트리의 지름
 - 1967과 동일하게 접근했으나, 시간초과 발생
 - visited 처리를 딱 두 번 잘못한 부분이 원인
 - 1967에 비해 edge가 많아, 이 문제에서만 초과 발생
 - 해당 부분 수정

## 1967, 1167를 DFS 2번으로 풀이한 방법
1. 루트노드(또는 임의의 노드)에 대해 가장 멀리있는 노드(A)를 찾는다.
2. A로부터 가장 멀리있는 노드까지의 거리가, 트리의 지름이다.

> 원 안의 임의의 점에서 가장 멀리 떨어진 점은, 원 테두리의 접점이다.